### PR TITLE
Added method to switch display between cut and no-cut output.

### DIFF
--- a/src/app/data model classes/range.ts
+++ b/src/app/data model classes/range.ts
@@ -29,6 +29,8 @@ export class Range {
 
     pvMaxNoCut: number; // maximum pV if future benefits are not cut
     pvMaxCut: number; // maximum pV if future benefits are cut
+    pvMinNoCut: number; // minimum pV if future benefits are not cut
+    pvMinCut: number; // minimum pV if future benefits are cut
 
     // identifiers (and array indices) for the various conditions
     static NO_CUT = 0;
@@ -46,6 +48,9 @@ export class Range {
     pvMaxArray = [0, 0]; // pvMaxArray[NO_CUT] is the maximum PV in the NO_CUT condition
     pvMaxRowArray = [0, 0]; // pvMaxRowArray[NO_CUT] is the row where the maximum PV in the NO_CUT condition is found
     pvMaxColArray = [0, 0];
+    pvMinArray = [1000000, 1000000]; // pvMinArray[NO_CUT] is the minimum PV in the NO_CUT condition
+    pvMinRowArray = [0, 0]; // pvMinRowArray[NO_CUT] is the row where the minimum PV in the NO_CUT condition is found
+    pvMinColArray = [0, 0];
 
     fractionBreak: number[] = [0.99, 0.95, 0.9, -1000000]; // values of pvFraction minima for different display colors
     fractionLabels: string[] = ["100", "99", "95", "90", "0"];
@@ -208,8 +213,25 @@ export class Range {
                     this.pvMaxColArray[condition] = col;
                 }
             }
+            if (pv < this.pvMinArray[condition]) {
+                this.pvMinArray[condition] = pv;
+                this.pvMinRowArray[condition] = row;
+                this.pvMinColArray[condition] = col;
+            }
 
         }
+    }
+
+    getMinimumPvClaimDates(condition: number) {
+        let row = this.pvMinRowArray[condition];
+        let column = this.pvMinColArray[condition];
+        return this.claimDatesArrays[condition][row][column]; 
+    }
+
+    getMaximumPvClaimDates(condition: number) {
+        let row = this.pvMaxRowArray[condition];
+        let column = this.pvMaxColArray[condition];
+        return this.claimDatesArrays[condition][row][column]; 
     }
 
     logArray(heading: string, array: number[][], decimalPlaces: number): void {
@@ -283,17 +305,15 @@ export class Range {
     initFracsAndColors(): void {
 
         let pvFrac: number;
-        let pvFracNoCut: number;
-        let pvFracCut: number;
-        let pvFrac2: number;
+        // let pvFracNoCut: number;
+        // let pvFracCut: number;
+        // let pvFrac2: number;
 
         let pvArray: number[][];
         let pvFracArray: number[][];
         let colorNumberArray: number[][];
         let pvMax: number;
         let colorNumber: number;
-        // let defaultColorNumber: number = this.fracBreak.length + 1;
-        // let pvFracDiff: number;
 
         for (let condition = Range.NO_CUT; condition <= Range.CUT; condition++) {
             pvArray = this.pvArrays[condition];

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -433,7 +433,13 @@
 
   <!--Recommended Strategy Output-->
   <h2>Recommended Strategy</h2>
-  <p>The strategy that maximizes the total dollars you can be expected to spend over your lifetime<span *ngIf="scenario.maritalStatus == 'married'">s</span> is as follows:</p>
+<!--   <p>The strategy that maximizes the total dollars you can be expected to spend over your lifetime<span *ngIf="scenario.maritalStatus == 'married'">s</span> is as follows:</p>
+  Also changed "spend" to "receive". Maybe the person will save some of those dollars.
+-->  
+  <p>
+    <span *ngIf="scenario.benefitCutAssumption">If the possible cut in benefits occurs, the </span>
+    <span *ngIf="!this.scenario.benefitCutAssumption">The </span>
+    strategy that maximizes the total dollars you can be expected to receive over your lifetime<span *ngIf="scenario.maritalStatus == 'married'">s</span> is as follows:</p>
   <ul>
     <li *ngFor="let claimingSolution of this.solutionSet.solutionsArray">{{claimingSolution.message}}</li>
   </ul>

--- a/src/app/range/range.component.css
+++ b/src/app/range/range.component.css
@@ -21,6 +21,10 @@ canvas {
     display: block;
 }
 
+form { 
+    margin: 0 auto; 
+    width:"{{canvasWidth+50}}";
+}
 
 .left {
     float: left;

--- a/src/app/range/range.component.html
+++ b/src/app/range/range.component.html
@@ -2,7 +2,19 @@
 <div>
     <h2>Range of Options</h2>
   <div class='container'>
-    <div class="left" style="max-width:900">
+<!--
+  possible future enhancement - to switch views
+  radio buttons not working as supposed to
+    <form>
+      <span style="font-weight:bold">Showing result:&nbsp;&nbsp;</span>
+        <input type="radio" id="showCut" (click)="showCut()">
+        <label for="showCut">If cut of 23% at 2034&nbsp;&nbsp;&nbsp;&nbsp;</label>
+    
+        <input type="radio" id="showNoCut" (click)="showNoCut()">
+        <label for="showNoCut">If no cut</label>
+    </form>
+ -->    
+ <div class="left" style="max-width:900">
       <canvas #canvas0 id="canvas0" title="Percent of Maximum canvas" (click)="selectCell($event, 0)" (mousemove)="update($event, 0)"
         (mouseenter)="startUpdating()" (mouseleave)="stopUpdating()" style="margin-right:20px">
       </canvas>
@@ -17,8 +29,8 @@
       <p style="font-weight:bold">Selected Option: </p>
       <ul>
         <!-- TODO: revise below IF CLAIM DATES ARE DIFFERENT FOR CUT AND NO_CUT CASES -->
-        <li>{{this.selectedClaimDatesStrNoCut}}</li>
-        <li>{{this.pctSelStr}}</li>
+        <li>{{this.selectedClaimDatesString}}</li>
+        <li>{{this.selectedPercentString}}</li>
       </ul>
     </span> 
 

--- a/src/app/range/range.component.html
+++ b/src/app/range/range.component.html
@@ -1,28 +1,47 @@
-<!-- <div class='parent'> -->
 <div>
     <h2>Range of Options</h2>
+    <span *ngIf="!scenario.benefitCutAssumption">
+      <p>For this case:</p>
+      <ul> 
+        <li>The highest expected present value is ${{this.maximumPvString}}, as noted above. </li>
+        <li>The lowest expected present value is ${{this.minimumPvString}}. </li>
+        <li>It occurs with: {{this.minimumPvClaimDatesString}}. </li>
+      </ul>
+    </span>
+    <span *ngIf="scenario.benefitCutAssumption">
+      <p>For this case, if there is a {{this.getCutString()}}:</p>
+      <ul> 
+        <li>The highest expected present value is ${{this.maximumPvStringCut}}, as noted above. </li>
+        <li>The lowest expected present value is ${{this.minimumPvStringCut}}. </li>
+        <li>It occurs with: {{this.minimumPvClaimDatesStringCut}}. </li>
+      </ul>
+      <p>If there is no cut:</p>
+      <ul> 
+        <li>The highest expected present value is ${{this.maximumPvString}}.</li>
+        <li>The lowest expected present value is ${{this.minimumPvString}}. </li>
+        <li>It occurs with: {{this.minimumPvClaimDatesString}}. </li>
+      </ul>
+    </span>
+    <p>The color-coded graph below shows the desirability of various alternative claiming dates.
+      For instance, the 95 - 99 range (color&nbsp;<span style="background-color:#56b4e9;">&nbsp;&nbsp;&nbsp;&nbsp;</span>) includes filing dates that would provide an expected present value from 95% to 99% of that of the recommended strategy.
+    </p>
   <div class='container'>
-<!--
-  possible future enhancement - to switch views
-  radio buttons not working as supposed to
-    <form>
+   
+    <form id="showCutForm">
       <span style="font-weight:bold">Showing result:&nbsp;&nbsp;</span>
-        <input type="radio" id="showCut" (click)="showCut()">
-        <label for="showCut">If cut of 23% at 2034&nbsp;&nbsp;&nbsp;&nbsp;</label>
+        <input type="radio" id="showCut" (click)="showCutChart(true)">
+        <label for="showCut">if {{this.getCutString()}}&nbsp;&nbsp;&nbsp;&nbsp;</label>
     
-        <input type="radio" id="showNoCut" (click)="showNoCut()">
-        <label for="showNoCut">If no cut</label>
+        <input type="radio" id="showNoCut" (click)="showCutChart(false)">
+        <label for="showNoCut">if no cut</label>
     </form>
- -->    
- <div class="left" style="max-width:900">
+
+    <div class="left" style="max-width:900">
       <canvas #canvas0 id="canvas0" title="Percent of Maximum canvas" (click)="selectCell($event, 0)" (mousemove)="update($event, 0)"
         (mouseenter)="startUpdating()" (mouseleave)="stopUpdating()" style="margin-right:20px">
       </canvas>
     </div>
-    
-    <p>This color-coded graph shows the desirability of various alternative claiming dates.
-      For instance, the dark green range includes filing dates that would provide an expected present value of at least 99% of that of the recommended strategy.
-    </p>
+
     <p *ngIf="selectedRow < 0">Click any spot on the graph to see how the selected alternative compares to the recommended filing date(s).</p>
     <p *ngIf="scenario.restrictedApplicationPossible">NOTE: Spousal benefit may be claimed before retirement benefit.</p>
     <span *ngIf="selectedRow >= 0">

--- a/src/app/range/range.component.html
+++ b/src/app/range/range.component.html
@@ -1,21 +1,22 @@
 <div>
     <h2>Range of Options</h2>
     <span *ngIf="!scenario.benefitCutAssumption">
-      <p>For this case,
+      <p>Under the conditions defined for this case,
         the expected present value ranges from ${{this.minimumPvString}} 
         to ${{this.maximumPvString}}
       </p>
     </span>
     <span *ngIf="scenario.benefitCutAssumption">
-      <p>For this case, if there is a {{this.getCutString()}}, 
-        the expected present value ranges from ${{this.minimumPvStringCut}} 
-        to ${{this.maximumPvStringCut}}
-      </p>
-      <p>If there is no cut,
-        the expected present value ranges from ${{this.minimumPvString}} 
-        to ${{this.maximumPvString}}
-      </p>
+      <p>Under the conditions defined for this case:</p>
+      <ul>
+        <li>If there is a {{this.getCutString()}}, the expected present value ranges from ${{this.minimumPvStringCut}} 
+          to ${{this.maximumPvStringCut}}</li>
+        <li>If there is no cut,
+          the expected present value ranges from ${{this.minimumPvString}} 
+          to ${{this.maximumPvString}}</li>
+      </ul>
     </span>
+    <!-- Moved the description to make more room beside the graph -->
     <p>The color-coded graph below shows the desirability of various alternative claiming dates.
       For instance, the 95 - 99 range (color&nbsp;<span style="background-color:#56b4e9;">&nbsp;&nbsp;&nbsp;&nbsp;</span>) includes filing dates that would provide an expected present value from 95% to 99% of that of the recommended strategy.
     </p>
@@ -37,32 +38,31 @@
     </div>
     
     <span *ngIf="selectedRow < 0">
-      <p>This color-coded graph shows the desirability of various alternative claiming dates.
-        For instance, the dark green range includes filing dates that would provide an expected present value of at least 99% of that of the recommended strategy.
-      </p>
       <p>Click any spot on the graph to see how the selected alternative compares to the recommended filing date(s).</p>
     </span>
     <p *ngIf="scenario.restrictedApplicationPossible">NOTE: A restricted application (i.e., an application for just spousal benefits) will be assumed, whenever it is available given the retirement filing dates selected.</p>
     <span *ngIf="selectedRow >= 0">
       <p style="font-weight:bold">Selected Option: </p>
-      <ul>
-        <!-- TODO: revise below IF CLAIM DATES ARE DIFFERENT FOR CUT AND NO_CUT CASES -->
-      <!-- Commenting these two lines out for now, since they are tenatively replaced by output below
-        <li>{{this.selectedClaimDatesString}}</li> 
-        <li>{{this.selectedPercentString}}</li>
-      -->
+      <span *ngIf="!scenario.benefitCutAssumption">
+        <ul>
         <li *ngFor="let claimingSolution of this.solutionSet.solutionsArray">{{claimingSolution.message}}</li>
         <li>The present value of the strategy you selected is {{this.selectedStrategyPV.toLocaleString('en-US', {style: 'currency',currency: 'USD', minimumFractionDigits:0, maximumFractionDigits:0})}}.</li>
-        <li>That is a difference of {{this.differenceInPV.toLocaleString('en-US', {style: 'currency',currency: 'USD', minimumFractionDigits:0, maximumFractionDigits:0})}}
-          ({{this.differenceInPV_asPercent.toLocaleString('en-US', {minimumFractionDigits:0, maximumFractionDigits:1})}}%) relative to the suggested filing strategy.</li>
-      </ul>
-    </span> 
+        <li>That is {{this.differenceInPV.toLocaleString('en-US', {style: 'currency',currency: 'USD', minimumFractionDigits:0, maximumFractionDigits:0})}}
+            ({{this.differenceInPV_asPercent.toLocaleString('en-US', {minimumFractionDigits:0, maximumFractionDigits:1})}}%) less than the suggested filing strategy.</li>
+        </ul>
+      </span>
+      <span *ngIf="scenario.benefitCutAssumption">
+        <ul>
+          <li *ngFor="let claimingSolution of this.solutionSet.solutionsArray">{{claimingSolution.message}}</li>
+        </ul>
+        <p style="font-weight:bold">{{this.cutOrNoCutString[this.currentCondition]}}:</p>
+        <ul>
+          <li>The present value of the strategy you selected is {{this.selectedStrategyPV.toLocaleString('en-US', {style: 'currency',currency: 'USD', minimumFractionDigits:0, maximumFractionDigits:0})}}.</li>
+          <li>That is {{this.differenceInPV.toLocaleString('en-US', {style: 'currency',currency: 'USD', minimumFractionDigits:0, maximumFractionDigits:0})}}
+              ({{this.differenceInPV_asPercent.toLocaleString('en-US', {minimumFractionDigits:0, maximumFractionDigits:1})}}%) less than the maximum.</li>
+        </ul>
+      </span> 
+    </span>
 
   </div>
-<!-- FOR POSSIBLE USE IF CLAIM DATES ARE DIFFERENT FOR CUT VS. NO_CUT CASES
-  <p>Claim dates at selection<span *ngIf="scenario.benefitCutAssumption === true"> (no cut)</span>: <span>{{this.selectedClaimDatesStrNoCut}}</span></p>
-  <p *ngIf="scenario.benefitCutAssumption === true">Claim dates at selection (cut): <span>{{this.selectedClaimDatesStrCut}}</span></p>
-  <p>Claim dates at pointer<span *ngIf="scenario.benefitCutAssumption === true"> (no cut)</span>: <span>{{this.pointerClaimDatesStrNoCut}}</span></p>
-  <p *ngIf="scenario.benefitCutAssumption === true">Claim dates at pointer: (cut) <span>{{this.pointerClaimDatesStrCut}}</span></p>
- -->
 </div>

--- a/src/app/range/range.component.ts
+++ b/src/app/range/range.component.ts
@@ -5,6 +5,14 @@ import { Person } from '../data model classes/person'
 import { Range } from '../data model classes/range'
 import { ClaimDates } from '../data model classes/claimDates'
 
+/* 
+This component provides a means of graphically displaying the quality of
+any possible claiming date (or, for a couple, combination of claiming dates).
+The "quality" measured is the percentage of the maximum expected PV calculated.
+As users interact with the chart, they see immediately that percentage for each
+claiming strategy, and they can select a specific strategy for further information. 
+ */
+
 // convenience constants to avoid references to a different class
 const NO_CUT = Range.NO_CUT
 const CUT = Range.CUT
@@ -31,19 +39,34 @@ export class RangeComponent implements OnInit, AfterViewInit {
   canvas: HTMLCanvasElement;
   canvasContext: CanvasRenderingContext2D
 
-  pctSelStr: string = "";
-  pctPtrStr: string = "";
+/* 
+  // for possible future view-switch enhancement
+  showCutButton: HTMLInputElement;
+  showNoCutButton: HTMLInputElement;
+ */
 
-  // Strings with starting dates
-  selectedClaimDatesStrNoCut: string;
-  selectedClaimDatesStrCut: string;
-  pointerClaimDatesStrNoCut: string;
-  pointerClaimDatesStrCut: string;
+  updating: boolean = false; // true if user has pointer over the graph
+  
+  // items relating to the selected option (clicked by user)
+  selectedRow: number = -1;
+  selectedCol: number = -1;
+  selectedPercentString: string = ""; // string with percent of maximum PV at selected option
+  selectedClaimDatesString: string; // string with claim dates for no-cut condition at selected option
+  selectedClaimDatesStringCut: string; // string with claim dates for cut condition at selected option
 
-  range: Range;
+  // items relating to the option under the pointer (as user hovers)
+  previousPointerRow: number = -1; 
+  previousPointerColumn: number = -1;
+  pointerPercentString: string = "";
+  pointerClaimDatesStringNoCut: string;
+  pointerClaimDatesStringCut: string;
+
+  range: Range; // the object holding data for the range of options
   startDateA: MonthYearDate; // date at which personA first receives benefits, to be used when converting row to date
   startDateB: MonthYearDate; // date at which personB first receives benefits, to be used when converting column to date
   
+  // - - - - - - graph parameters - - - - - -
+
   cellWidth: number;
   cellHeight: number;
   minimumCellWidth: number = 6;
@@ -53,11 +76,11 @@ export class RangeComponent implements OnInit, AfterViewInit {
   axisWidth: number = 2; // width of x- or y-axis
   halfAxisWidth: number = this.axisWidth / 2;
   axisColor: string = 'gray';
-  axisTitleFontSize = 14;
-  axisTitleFont: string = this.axisTitleFontSize + 'px serif';
-  axisLabelFontSize = 14;
-  axisLabelFont: string = this.axisLabelFontSize + 'px serif';
-  chartTitleFontSize = 16;
+  axisTitleFontSize = 16;
+  axisTitleFont: string = this.axisTitleFontSize + 'px sans-serif';
+  axisLabelFontSize = 16;
+  axisLabelFont: string = this.axisLabelFontSize + 'px sans-serif';
+  chartTitleFontSize = 18;
   chartTitleFont: string = 'bold ' + this.chartTitleFontSize + 'px serif';
   chartTitleHeight: number;
   axisTickSize: number = 10;
@@ -87,8 +110,8 @@ export class RangeComponent implements OnInit, AfterViewInit {
   keySpace: number; // between bottom of chart title and top of key
   keyBorderWidth: number = 2; // width of border around color key for display
   keyBorderColor: string = '#808080';
-  keyLabelFontHeight: number = 14;
-  keyLabelFont: string = this.keyLabelFontHeight + 'px serif';
+  keyLabelFontHeight: number = 16;
+  keyLabelFont: string = this.keyLabelFontHeight + 'px sans-serif';
   keyCellCount: number;
   keyCellWidth: number = 40;
   keyCellHeight: number = 30;
@@ -100,14 +123,6 @@ export class RangeComponent implements OnInit, AfterViewInit {
 
   markWidth: number = 2; // width of line marking selected cell or cell at pointer
   halfMarkWidth: number = this.markWidth/2; // width of line marking selected cell or cell at pointer
-
-  selectedRow: number = -1;
-  selectedCol: number = -1;
-  prevPointerRow: number = -1;
-  prevPointerCol: number = -1;
-  updating: boolean = false;
-
-  prevPvNoCut: number = 0;
 
   selectedColor = 'black'; // mark of selected cell
   pointerColor = 'rgb(250, 250, 20)'; // yellow, border around cell at pointer location
@@ -131,13 +146,13 @@ export class RangeComponent implements OnInit, AfterViewInit {
 
       this.startDateA = this.range.firstDateA;
       this.startDateB = this.range.firstDateB;
-      this.pctSelStr = "";
+      this.selectedPercentString = "";
       this.selectedRow = -1;
       this.selectedCol = -1;
 
       if (this.scenario.benefitCutAssumption === false) {
         this.currentCondition = NO_CUT;
-        this.chartTitleStr = "% of Maximum PV (If No Cut)"
+        this.chartTitleStr = "% of Maximum PV"
       } else {
         this.currentCondition = CUT;
         this.chartTitleStr = "% of Maximum PV (If Cut of " + 
@@ -149,20 +164,39 @@ export class RangeComponent implements OnInit, AfterViewInit {
       this.canvas = this.canvasRef.nativeElement;
       this.canvasContext = this.canvas.getContext("2d");
 
-      this.prevPvNoCut = this.scenario.pvNoCut;
+/* 
+  // for possible future view-switch enhancement
+      this.showCutButton = <HTMLInputElement> document.getElementById("showCut");
+      this.showNoCutButton = <HTMLInputElement> document.getElementById("showNoCut");
+*/
 
-      this.setSizes(this.range.rows, this.range.cols);
+      this.setSizes(this.range.rows, this.range.columns);
 
       this.cellBaseX = this.yMarginWidth + this.axisWidth;
       this.cellBaseY = this.cellHeight * (this.range.rows - 1);
       this.rowBaseY = (this.cellHeight * this.range.rows) - 1;
 
-      this.selectedClaimDatesStrNoCut = "";
-      this.pointerClaimDatesStrNoCut = "";
+      this.selectedClaimDatesString = "";
+      this.pointerClaimDatesStringNoCut = "";
+      this.pointerClaimDatesStringCut = "";
 
       this.paintCanvas(this.currentCondition);
   }
 }
+/* 
+// for possible future view-switch enhancement
+showCut(): void {
+  this.showCutButton.checked = true;
+  this.showNoCutButton.checked = false;
+  console.log("showing Cut");
+}
+
+showNoCut(): void {
+  this.showNoCutButton.checked = true;
+  this.showCutButton.checked = false;
+  console.log("showing NoCut");
+}
+*/
 
   updateDisplay(event: Event) {
     this.initDisplay();
@@ -173,14 +207,14 @@ export class RangeComponent implements OnInit, AfterViewInit {
     // i.e., different number of possible claim date combinations 
 
     let maxCells = this.range.rows;
-    if (maxCells < this.range.cols) {
-      maxCells = this.range.cols;
+    if (maxCells < this.range.columns) {
+      maxCells = this.range.columns;
     }
 
     this.setKeySize();
 
-    let maxCanvasDimension = 500;
-    this.cellWidth = Math.floor(Math.max(maxCanvasDimension/maxCells, this.minimumCellWidth));
+    let maximumCanvasDimension = 500;
+    this.cellWidth = Math.floor(Math.max(maximumCanvasDimension/maxCells, this.minimumCellWidth));
     this.cellHeight = Math.floor(Math.max(this.cellWidth, this.minimumCellHeight));
 
     if (rows === 1) {
@@ -195,19 +229,19 @@ export class RangeComponent implements OnInit, AfterViewInit {
     }
 
     // Calculate chart element dimensions to fit actual axis contents
-    let ctx:CanvasRenderingContext2D = this.canvasContext;
-    ctx.font = this.axisTitleFont;
-    this.xTitleWidth = ctx.measureText(this.xAxisTitle).width;
+    let context:CanvasRenderingContext2D = this.canvasContext;
+    context.font = this.axisTitleFont;
+    this.xTitleWidth = context.measureText(this.xAxisTitle).width;
     this.xTitleHeight = this.axisTitleFontSize * 1.5;
-    this.yTitleWidth = ctx.measureText(this.yAxisTitle).width;      
+    this.yTitleWidth = context.measureText(this.yAxisTitle).width;      
     this.yTitleHeight = this.axisTitleFontSize * 1.5;
     this.chartTitleHeight = this.chartTitleFontSize * 2;
     this.keySpace = this.chartTitleFontSize;
-    ctx.font = this.axisLabelFont;
-    this.labelWidth = ctx.measureText("2020").width;
+    context.font = this.axisLabelFont;
+    this.labelWidth = context.measureText("2020").width;
     this.labelHeight = this.axisLabelFontSize * 1.5;
 
-    let cellsWidth = (this.range.cols * this.cellWidth); // width of all cells
+    let cellsWidth = (this.range.columns * this.cellWidth); // width of all cells
     this.xMarginWidth = Math.max(cellsWidth, this.xTitleWidth, this.yTitleWidth, this.keyWidth);
     this.xMarginWidth = Math.floor(this.xMarginWidth + 1);
 
@@ -218,7 +252,11 @@ export class RangeComponent implements OnInit, AfterViewInit {
       this.xMarginHeight += Math.floor(this.yTitleHeight + 1);
     }
 
-    this.yMarginWidth = Math.floor(this.labelWidth + this.axisLabelSpace + 1);
+    if (rows === 1) {
+      this.yMarginWidth = 0;
+    } else {
+      this.yMarginWidth = Math.floor(this.labelWidth + this.axisLabelSpace + 1);
+    }
     this.yMarginHeight = Math.floor(this.range.rows * this.cellHeight + 1);
 
     this.canvasWidth = this.yMarginWidth + this.axisWidth + this.xMarginWidth;
@@ -228,7 +266,7 @@ export class RangeComponent implements OnInit, AfterViewInit {
   }
 
   // get x, y coordinates of upper left corner of cell at row, col
-  getCellUL(row: number, col: number): number[] {
+  getCellUpperLeft(row: number, col: number): number[] {
     // leaving space for border around cells
     let ulX: number = this.cellBaseX + (col * this.cellWidth);
     let ulY: number = this.cellBaseY - (row * this.cellHeight);
@@ -237,70 +275,70 @@ export class RangeComponent implements OnInit, AfterViewInit {
 
   paintCell(condition: number, row: number, col: number) {
     let color: string;
-    let ul: number[] = this.getCellUL(row, col); // ul[0] = x, ul[1] = y
+    let upperLeft: number[] = this.getCellUpperLeft(row, col); // ul[0] = x, ul[1] = y
     color = this.range.getColor(condition, row, col);
     this.canvasContext.fillStyle = color;
-    this.canvasContext.fillRect(ul[0], ul[1], this.cellWidth, this.cellHeight);
+    this.canvasContext.fillRect(upperLeft[0], upperLeft[1], this.cellWidth, this.cellHeight);
   }
 
   paintMargins() {
-    let ctx: CanvasRenderingContext2D = this.canvasContext;
-    ctx.strokeStyle = this.axisColor;
-    ctx.lineWidth = this.axisWidth;
+    let context: CanvasRenderingContext2D = this.canvasContext;
+    context.strokeStyle = this.axisColor;
+    context.lineWidth = this.axisWidth;
     let isCouple: boolean = this.range.rows > 1;
     
     // draw y-axis and x-axis
     let axisLeft: number = this.cellBaseX - this.halfAxisWidth;
-    let axisRight: number = this.cellBaseX + (this.range.cols * this.cellWidth);
+    let axisRight: number = this.cellBaseX + (this.range.columns * this.cellWidth);
     let axisBottom: number = this.cellBaseY + this.cellHeight + this.halfAxisWidth;
     let axisTop: number = 0; // works for couple
     if (!isCouple) {
       axisTop = axisBottom;
     }    
-    ctx.beginPath();
-    ctx.moveTo(axisLeft, axisTop);
-    ctx.lineTo(axisLeft, axisBottom);
-    ctx.lineTo(axisRight, axisBottom);
-    ctx.stroke();
+    context.beginPath();
+    context.moveTo(axisLeft, axisTop);
+    context.lineTo(axisLeft, axisBottom);
+    context.lineTo(axisRight, axisBottom);
+    context.stroke();
 
     // add x-axis title
     let titleX = axisLeft + (this.xMarginWidth / 2);
     let titleY = axisBottom + this.labelHeight + this.xTitleHeight;
-    ctx.font = this.axisTitleFont;
-    ctx.fillStyle = 'black';
-    ctx.textAlign = 'center';
-    ctx.fillText(this.xAxisTitle, titleX, titleY);
+    context.font = this.axisTitleFont;
+    context.fillStyle = 'black';
+    context.textAlign = 'center';
+    context.fillText(this.xAxisTitle, titleX, titleY);
 
     if (isCouple) {
       // add y-axis title
       titleY += this.yTitleHeight;
       titleX = axisLeft;
-      ctx.font = this.axisTitleFont;
-      ctx.fillStyle = 'black';
-      ctx.textAlign = 'center';
-      ctx.textAlign = 'left';
-      ctx.fillText(this.yAxisTitle, titleX, titleY);
+      context.font = this.axisTitleFont;
+      context.fillStyle = 'black';
+      context.textAlign = 'center';
+      context.textAlign = 'left';
+      context.fillText(this.yAxisTitle, titleX, titleY);
       // draw arrow towards yMargin
-      ctx.beginPath();
+      context.beginPath();
       let fontSize = this.axisTitleFontSize;
       let arrowheadBottom = axisBottom + fontSize;
-      ctx.moveTo(titleX - 5, titleY - (fontSize / 2)); 
+      context.moveTo(titleX - 5, titleY - (fontSize / 2)); 
       let turnX: number = titleX - this.yMarginWidth / 2
-      ctx.lineTo(turnX, titleY - fontSize/2);
-      ctx.lineTo(turnX, axisBottom);
-      ctx.lineTo(turnX - fontSize/2, arrowheadBottom);
-      ctx.lineTo(turnX + fontSize/2, arrowheadBottom);
-      ctx.lineTo(turnX, axisBottom);
-      ctx.stroke();
+      context.lineTo(turnX, titleY - fontSize/2);
+      context.lineTo(turnX, axisBottom);
+      context.lineTo(turnX - fontSize/2, arrowheadBottom);
+      context.lineTo(turnX + fontSize/2, arrowheadBottom);
+      context.lineTo(turnX, axisBottom);
+      context.stroke();
     }
 
     // add chart title
-    ctx.font = this.chartTitleFont;
-    ctx.fillStyle = 'black';
-    ctx.textAlign = 'center';
+    context.font = this.chartTitleFont;
+    context.fillStyle = 'black';
+    context.textAlign = 'center';
     titleY += this.chartTitleHeight;
     titleX = this.canvasWidth / 2;
-    ctx.fillText(this.chartTitleStr, titleX, titleY);
+    context.fillText(this.chartTitleStr, titleX, titleY);
 
     // add key
     this.drawKey(this.currentCondition, titleX - (this.keyWidth / 2), titleY + this.chartTitleFontSize);
@@ -313,22 +351,22 @@ export class RangeComponent implements OnInit, AfterViewInit {
 
     let labelX: number;
     let labelY: number = tickTop + this.labelHeight;
-    ctx.font = this.axisLabelFont;
-    ctx.fillStyle = 'black';
-    ctx.textAlign = 'center';
+    context.font = this.axisLabelFont;
+    context.fillStyle = 'black';
+    context.textAlign = 'center';
     
     let year = this.range.firstYearA;
     for (let i = 0; i < this.range.yearMarksA.length; i++) {
-      ctx.beginPath();
-      ctx.moveTo(tickX, tickTop);
-      ctx.lineTo(tickX, tickBottom);
-      ctx.stroke();
+      context.beginPath();
+      context.moveTo(tickX, tickTop);
+      context.lineTo(tickX, tickBottom);
+      context.stroke();
       if (i < this.range.yearMarksA.length - 1) {
         // draw label for this range
         nextX = this.cellBaseX + (this.range.yearMarksA[i + 1] * this.cellWidth)
         if ((nextX - tickX) > this.labelWidth) {
           labelX = (nextX + tickX) / 2;
-          ctx.fillText(year.toString(), labelX, labelY);
+          context.fillText(year.toString(), labelX, labelY);
         }
         year++;
         tickX = nextX;
@@ -338,23 +376,23 @@ export class RangeComponent implements OnInit, AfterViewInit {
     if (isCouple) {
       // add y-axis tick marks and year labels
       year = this.range.firstYearB;
-      ctx.textAlign = 'right';
+      context.textAlign = 'right';
       let tickRight: number = axisLeft - this.halfAxisWidth;
       let tickLeft: number = tickRight - this.axisTickSize;
       let tickY: number = axisBottom;
       let nextY: number;
       let labelX: number = tickRight - this.axisLabelSpace;
       for (let i = 0; i < this.range.yearMarksB.length; i++) {
-        ctx.beginPath();
-        ctx.moveTo(tickLeft, tickY);
-        ctx.lineTo(tickRight, tickY);
-        ctx.stroke();
+        context.beginPath();
+        context.moveTo(tickLeft, tickY);
+        context.lineTo(tickRight, tickY);
+        context.stroke();
         if (i < this.range.yearMarksB.length - 1) {
           // draw label for this range
           nextY = this.rowBaseY - ((this.range.yearMarksB[i + 1]) * this.cellWidth)
           if ((tickY - nextY) > this.labelHeight) {
             labelY = (nextY + tickY) / 2 + this.axisLabelFontSize/2;
-            ctx.fillText(year.toString(), labelX, labelY);
+            context.fillText(year.toString(), labelX, labelY);
           }
           year++;
           tickY = nextY;
@@ -370,67 +408,61 @@ export class RangeComponent implements OnInit, AfterViewInit {
     this.paintMargins();
     
     for (let row = 0; row < this.range.rows; row++) {
-      for (let col = 0; col < this.range.cols; col++) {
+      for (let col = 0; col < this.range.columns; col++) {
         this.paintCell(condition, row, col);
       }
     }
   }
 
   clearData() {
-    this.pointerClaimDatesStrNoCut = '';
-    this.pointerClaimDatesStrCut = '';
+    this.pointerClaimDatesStringNoCut = '';
+    this.pointerClaimDatesStringCut = '';
 
-    this.pctPtrStr = '';
+    this.pointerPercentString = '';
   }
 
-  roundSignificantDigits(num: number, digits: number) {
-    // One could use this to show a simpler version of the PV,
-    // but that would not agree with the nearest-dollar value shown elsewhere
-    let numInt = Math.round(num);
-    // could use numInt.toPrecision(digits)
-    // below also adds commas as thousand separators
-    return numInt.toLocaleString('en-US', { maximumSignificantDigits: digits })
-  }
-
-  fracToPct(num: number, places: number) {
+ fractionToPercent(num: number, places: number) {
     return (num * 100).toFixed(places);
   }
 
-  showSelStarts(row: number, col: number, ) {
-    let selectedClaimDatesNoCut = this.range.claimDatesArrays[this.currentCondition][row][col];
+  showSelectedOption(row: number, col: number, ) {
+    let selectedClaimDates: ClaimDates = this.range.claimDatesArrays[this.currentCondition][row][col];
     console.log("row: " + row)
     console.log("col: " + col)
-    this.selectedClaimDatesStrNoCut = selectedClaimDatesNoCut.benefitDatesString();
-    // this.homeSetCustomDates(selectedClaimDatesNoCut)
-    // let expectedPvStr: string = Math.round(this.range.getPv(this.currentCondition, row, col)).toLocaleString();
-    let expectedPvPct: string = this.fracToPct(this.range.getPvFrac(this.currentCondition, row, col), 1);
+    this.selectedClaimDatesString = selectedClaimDates.benefitDatesString();
+    let expectedPvPercent: string = this.fractionToPercent(this.range.getPvFraction(this.currentCondition, row, col), 1);
     // this.pctSelStr = "Expected PV = $" + expectedPvStr + ", " + expectedPvPct + "% of max. PV";
-    this.pctSelStr = "Expected PV = " + expectedPvPct + "% of maximum PV";
-    if (this.currentCondition > NO_CUT) {
-      let expectedPvPctNoCut: string = this.fracToPct(this.range.getPvFrac(NO_CUT, row, col), 1);
-      this.pctSelStr += " (" + expectedPvPctNoCut + "% if no cut)";
+    this.selectedPercentString = "Expected PV = " + expectedPvPercent + "% of maximum PV";
+    if (this.currentCondition == CUT) {
+      let expectedPvPercentNoCut: string = this.fractionToPercent(this.range.getPvFraction(CUT, row, col), 1);
+      this.selectedPercentString += 
+        " if cut of " +
+        this.scenario.benefitCutPercentage + "% at " +
+        this.scenario.benefitCutYear;
+        expectedPvPercentNoCut + 
+        " if no cut"; 
     }
-  if (this.currentCondition == CUT) {
-      let selectedClaimDatesCut = this.range.claimDatesArrays[CUT][row][col];
-      // TODO: show only if dates different for CUT case
-      this.selectedClaimDatesStrCut = selectedClaimDatesCut.benefitDatesString();
-    }
+    // if (this.currentCondition == CUT) {
+    //   let selectedClaimDatesCut = this.range.claimDatesArrays[CUT][row][col];
+    //   // TODO: show only if dates different for CUT case
+    //   this.selectedClaimDatesStringCut = selectedClaimDatesCut.benefitDatesString();
+    // }
   }
 
-  getRowCol(e: MouseEvent) { // returnValue[0] = x, returnValue[1] = y
+  getRowColumn(e: MouseEvent) { // returnValue[0] = x, returnValue[1] = y
     let xy = this.getXY(e);
     let x = xy[0];
     let y = xy[1];
     let row = Math.floor((this.rowBaseY - y) / this.cellHeight);
-    let col = Math.floor((x - this.cellBaseX) / this.cellWidth);
-    // row & col should not be out of range, but just in case:
+    let column = Math.floor((x - this.cellBaseX) / this.cellWidth);
+    // row & column should not be out of range, but just in case:
     if (row >= this.range.rows) {
       row = this.range.rows - 1
     }
-    if (col >= this.range.cols) {
-      col = this.range.cols - 1
+    if (column >= this.range.columns) {
+      column = this.range.columns - 1
     } 
-    return [row, col];
+    return [row, column];
   }
 
   getXY(e: MouseEvent) {
@@ -446,9 +478,9 @@ export class RangeComponent implements OnInit, AfterViewInit {
     }
   }
 
-  markCell(markColor: string, markRow: number, markCol: number) {
-    if (markRow >= 0 && markCol >= 0) { // to avoid marking the initial selected cell at (-1, -1)
-      let ul: number[] = this.getCellUL(markRow, markCol);
+  markCell(markColor: string, markRow: number, markColumn: number) {
+    if (markRow >= 0 && markColumn >= 0) { // to avoid marking the initial selected cell at (-1, -1)
+      let ul: number[] = this.getCellUpperLeft(markRow, markColumn);
       this.canvasContext.lineWidth = this.markWidth;
       this.canvasContext.strokeStyle = markColor;
       // Marking cell at the pointer with a rectangle
@@ -457,31 +489,31 @@ export class RangeComponent implements OnInit, AfterViewInit {
     }
   }
 
-  selectCell(e: MouseEvent) {
-    let rowCol = this.getRowCol(e);
+  selectCell(event: MouseEvent) {
+    let rowColumn = this.getRowColumn(event);
     // save location of newly-selected cell
-    let selectRow = rowCol[0];
-    let selectCol = rowCol[1];
-    if ((selectRow >= 0) && (selectCol >= 0)) {
+    let selectRow = rowColumn[0];
+    let selectColumn = rowColumn[1];
+    if ((selectRow >= 0) && (selectColumn >= 0)) {
       // unmark the previously-selected cell
       this.unmarkCell(this.selectedRow, this.selectedCol);
       // mark the newly-selected cell
-      this.markCell(this.selectedColor, selectRow, selectCol);
+      this.markCell(this.selectedColor, selectRow, selectColumn);
       // save selected cell row & col for other operations 
       this.selectedRow = selectRow;
-      this.selectedCol = selectCol;
-      this.showSelStarts(this.selectedRow, this.selectedCol);
+      this.selectedCol = selectColumn;
+      this.showSelectedOption(this.selectedRow, this.selectedCol);
       // this.showPct(this.selectedRow, this.selectedCol, this.pctSelStr);
       let condition: number = NO_CUT;
       if (this.scenario.benefitCutAssumption) {
         condition = CUT;
       }
-      let expectedPvStr: string = Math.round(this.range.getPv(condition, selectRow, selectCol)).toLocaleString();
-      let expectedPvPct: string = this.fracToPct(this.range.getPvFrac(this.currentCondition, selectRow, selectCol), 1);
-      this.pctSelStr = "Expected PV = $" + expectedPvStr + ", " + expectedPvPct + "% of maximum PV";
+      let expectedPvString: string = Math.round(this.range.getPv(condition, selectRow, selectColumn)).toLocaleString();
+      let expectedPvPercentString: string = this.fractionToPercent(this.range.getPvFraction(this.currentCondition, selectRow, selectColumn), 1);
+      this.selectedPercentString = "Expected PV = $" + expectedPvString + ", " + expectedPvPercentString + "% of maximum PV";
       if (this.currentCondition > NO_CUT) {
-        let expectedPvPctNoCut: string = this.fracToPct(this.range.getPvFrac(NO_CUT, selectRow, selectCol), 1);
-        this.pctSelStr += " (" + expectedPvPctNoCut + "% if no cut)";
+        let expectedPvPercentNoCut: string = this.fractionToPercent(this.range.getPvFraction(NO_CUT, selectRow, selectColumn), 1);
+        this.selectedPercentString += " (" + expectedPvPercentNoCut + "% if no cut)";
       }
     }
 }
@@ -491,55 +523,56 @@ export class RangeComponent implements OnInit, AfterViewInit {
     this.updating = true;
   }
 
-  stopUpdating() {
-    this.updating = false;
-    this.unmarkCell(this.prevPointerRow, this.prevPointerCol);
-    if ((this.prevPointerRow === this.selectedRow) || (this.prevPointerCol === this.selectedCol)) {
+  // unmark the pointer location
+  unmarkPointer() {
+    this.unmarkCell(this.previousPointerRow, this.previousPointerColumn);
+    if ((this.previousPointerRow === this.selectedRow) && (this.previousPointerColumn === this.selectedCol)) {
       // if the most recent pointer location was the selected cell, re-mark it
       this.markCell(this.selectedColor, this.selectedRow, this.selectedCol);
     }
+  }
+
+  stopUpdating() {
+    this.updating = false;
+    this.unmarkPointer();
     this.clearData();
   }
 
 update(e: MouseEvent) {
-    let rowCol = this.getRowCol(e);
-    let row = rowCol[0];
-    let col = rowCol[1];
+    let rowColumn = this.getRowColumn(e);
+    let row = rowColumn[0];
+    let column = rowColumn[1];
 
-    // unmark the pointer location
-    this.unmarkCell(this.prevPointerRow, this.prevPointerCol);
-    if ((this.prevPointerRow === this.selectedRow) && (this.prevPointerCol === this.selectedCol)) {
-      // re-mark the selected cell
-      this.markCell(this.selectedColor, this.selectedRow, this.selectedCol);
-    }
+    this.unmarkPointer();
 
-    if ((row >= 0) && (col >= 0)) {
+    if ((row >= 0) && (column >= 0)) { // pointer is within the graph area (not the margin)
       // mark the pointer location, even if it is the selected cell
-      this.markCell(this.pointerColor, row, col)
-      this.prevPointerRow = row;
-      this.prevPointerCol = col;
-      let claimsStr = this.range.rowColumnDatesString(row, col);
-      this.pctPtrStr = this.fracToPct(this.range.getPvFrac(this.currentCondition, row, col), 1) + "% of max., " + claimsStr;
+      this.markCell(this.pointerColor, row, column)
+      this.previousPointerRow = row;
+      this.previousPointerColumn = column;
+      let claimsString = this.range.rowColumnDatesString(row, column);
+      this.pointerPercentString = this.fractionToPercent(this.range.getPvFraction(this.currentCondition, row, column), 1) + "% of maximum, " + claimsString;
       if (this.currentCondition > NO_CUT) {
-        let expectedPvPctNoCut: string = this.fracToPct(this.range.getPvFrac(NO_CUT, row, col), 1);
-        this.pctPtrStr += " (" + expectedPvPctNoCut + "% if no cut)";
+        let expectedPvPercentNoCut: string = this.fractionToPercent(this.range.getPvFraction(NO_CUT, row, column), 1);
+        this.pointerPercentString += " (" + expectedPvPercentNoCut + "% if no cut)";
       }
-      this.canvas.title = this.pctPtrStr
+      this.canvas.title = this.pointerPercentString; // show tooltip with % of maximum
+    } else {
+      this.canvas.title = ""; // blank tooltip when outside of graph
     }
   }
 
   setKeySize() {
     // determine location and size of key components
 
-    let ctx: CanvasRenderingContext2D = this.canvasContext;
-    this.keyCellsWidth = (this.keyCellWidth * this.range.fracLabels.length);
+    this.keyCellsWidth = (this.keyCellWidth * this.range.fractionLabels.length);
     this.keyWidth = this.keyCellsWidth + this.keyBorderWidth * 2;
     this.keyHeight = this.keyCellHeight + (this.keyBorderWidth * 2) + this.keyLabelFontHeight * 1.5;
     
   }
 
   drawKey(condition: number, keyLeft: number, keyTop: number): void {
-    let ctx: CanvasRenderingContext2D = this.canvasContext;
+    let context: CanvasRenderingContext2D = this.canvasContext;
     let borderWidth = this.keyBorderWidth;
     let halfWidth = borderWidth / 2; 
 
@@ -547,28 +580,28 @@ update(e: MouseEvent) {
     let cellsTop = keyTop + this.keyBorderWidth;
     let borderLeft = cellsLeft - halfWidth;
     let borderTop = cellsTop - halfWidth;
-    ctx.strokeStyle = this.keyBorderColor;
-    ctx.lineWidth = this.keyBorderWidth;
-    ctx.strokeRect(borderLeft, borderTop, this.keyCellsWidth + borderWidth, 
+    context.strokeStyle = this.keyBorderColor;
+    context.lineWidth = this.keyBorderWidth;
+    context.strokeRect(borderLeft, borderTop, this.keyCellsWidth + borderWidth, 
       this.keyCellHeight + borderWidth);
     
-    // paint cells and cell labels
-    let keyCellCount = this.range.fracLabels.length;
+    // paint key cells and key cell labels
+    let keyCellCount = this.range.fractionLabels.length;
     let cellX = cellsLeft;
     let labelY = cellsTop + this.keyCellHeight + (this.keyBorderWidth * 2) + this.keyLabelFontHeight;
-    ctx.fillStyle = 'black';
-    ctx.textAlign ='left';
-    ctx.font = this.keyLabelFont;
-    ctx.textAlign ='center';
-    // let fracIDy = cellsUly + this.cellHeight + this.keyBorderWidth + 2;
-    let fracNumber = keyCellCount - 1;
+    context.fillStyle = 'black';
+    context.textAlign ='left';
+    context.font = this.keyLabelFont;
+    context.textAlign ='center';
+    // which key element is being painted - higher array index for lower % of maximum
+    let fractionNumber = keyCellCount - 1; 
     for (let i = 0; i < keyCellCount; i++) {
-      ctx.fillStyle = this.range.colorByNumber[condition][fracNumber];
-      ctx.fillRect(cellX, cellsTop, this.keyCellWidth, this.keyCellHeight);
-      ctx.fillStyle = 'black';
-      ctx.fillText(this.range.fracLabels[fracNumber], cellX, labelY);
+      context.fillStyle = this.range.colorByNumber[condition][fractionNumber];
+      context.fillRect(cellX, cellsTop, this.keyCellWidth, this.keyCellHeight);
+      context.fillStyle = 'black';
+      context.fillText(this.range.fractionLabels[fractionNumber], cellX, labelY);
       cellX += this.keyCellWidth;
-      fracNumber--;
+      fractionNumber--;
     }
   }
 


### PR DESCRIPTION
Your latest commit (using functions in solutionset.service to create strings related to the selected filling date(s), which are then used to populate an unordered list.) is very helpful. I had started developing the features included in this commit, and git was able to merge the files, each with their own changes, without many conflicts.
This is the first stage of an attempt to clarify to the user the results of choosing to consider a possible future cut in benefits. One thing I hope the user will notice is that, in many cases, a filing strategy that is good for the no-cut condition is also good for the cut condition. The actual present value is, of course, significantly different, but the percentage of maximum is often quite similar.